### PR TITLE
Perhaps the last KFO-Server-AOV merge?

### DIFF
--- a/server/area.py
+++ b/server/area.py
@@ -955,7 +955,9 @@ class Area:
                 frames_realization="",
                 frames_sfx="",
                 additive=0,
-                effect="", 
+                effect="",
+                blipname="",
+                slide=0,
                 targets=None,
                 third_charid=-1,
                 third_folder="",
@@ -1189,6 +1191,8 @@ class Area:
                            frames_sfx,
                            additive,
                            effect,
+                           blipname,
+                           slide,
                            third_charid,
                            third_folder,
                            third_emote,
@@ -1243,6 +1247,8 @@ class Area:
             frames_sfx,  # 27
             additive,  # 28
             effect,  # 29
+            blipname,
+            slide,
             third_charid, # 30
             third_folder, # 31
             third_emote, # 32
@@ -1302,6 +1308,8 @@ class Area:
                 frames_sfx,  # 27
                 additive,  # 28
                 effect,  # 29
+                blipname,
+                slide,
                 third_charid, # 30
                 third_folder, # 31
                 third_emote, # 32

--- a/server/commands/music.py
+++ b/server/commands/music.py
@@ -205,19 +205,31 @@ def ooc_cmd_play(client, arg):
     """
     if len(arg) == 0:
         raise ArgumentError("You must specify a song.")
-    client.change_music(arg, client.char_id, "", 2,
-                        True)  # looped change music
+    if client not in client.area.owners:
+        client.area._owners.add(client) #I cannot be arsed editing the change music code, so fuck it, temp CM
+        client.change_music(arg, client.char_id, "", 2,
+                            True)
+        client.area._owners.remove(client)
+    else:
+        client.change_music(arg, client.char_id, "", 2,
+                            True)  # looped change music
 
 
 def ooc_cmd_play1(client, arg):
     """
     Play a track without looping it. See /play for this command with looping.
-    Usage: /play_once <name>
+    Usage: /play1 <name>
     """
     if len(arg) == 0:
         raise ArgumentError("You must specify a song.")
-    client.change_music(arg, client.char_id, "", 2,
-                        False)  # non-looped change music
+    if client not in client.area.owners:
+        client.area._owners.add(client)
+        client.change_music(arg, client.char_id, "", 2,
+                            False)
+        client.area._owners.remove(client)
+    else:
+        client.change_music(arg, client.char_id, "", 2,
+                            False)  # non-looped change music
 
 
 @mod_only()

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -375,6 +375,8 @@ class AOProtocol(asyncio.Protocol):
         effect = ""
         pair_order = 0
         third_charid = -1
+        blipname = ""
+        slide = 0
         if self.validate_net_cmd(
             args,
             self.ArgType.STR,  # msg_type
@@ -566,6 +568,77 @@ class AOProtocol(asyncio.Protocol):
                 self.client.send_ooc(
                     "Something went wrong! Please report the issue to the developers.")
                 return
+        elif self.validate_net_cmd(
+            args,
+            self.ArgType.STR, # 0 # msg_type
+            self.ArgType.STR_OR_EMPTY, # 1  # pre
+            self.ArgType.STR, # 2 # folder
+            self.ArgType.STR_OR_EMPTY, # 3 # anim
+            self.ArgType.STR_OR_EMPTY, # 4  # text
+            self.ArgType.STR, # 5 # pos
+            self.ArgType.STR, # 6 # sfx
+            self.ArgType.INT, # 7 # emote_mod
+            self.ArgType.INT, # 8 # cid
+            self.ArgType.INT, # 9 # sfx_delay
+            self.ArgType.INT_OR_STR, # 10 # button
+            self.ArgType.INT, # 11 # evidence
+            self.ArgType.INT, # 12 # flip
+            self.ArgType.INT, # 13 # ding
+            self.ArgType.INT, # 14 # color
+            self.ArgType.STR_OR_EMPTY, # 15 # showname
+            self.ArgType.STR, # 16 # charid_pair
+            self.ArgType.STR, # 17 # offset_pair
+            self.ArgType.INT, # 18 # nonint_pre
+            self.ArgType.STR, # 19 # sfx_looping
+            self.ArgType.INT, # 20 # screenshake
+            self.ArgType.STR, # 21 # frames_shake
+            self.ArgType.STR, # 22 # frames_realization
+            self.ArgType.STR, # 23 # frames_sfx
+            self.ArgType.INT, # 24 # additive
+            self.ArgType.STR, # 25  # effect
+            self.ArgType.STR, # 26 # blipname
+            self.ArgType.INT, # 27 # slide
+        ):
+            # 2.10 validation monstrosity. (FUCK IT WE BALL FUCK IT WE BALL FUCK IT WE BALL)
+            (
+                msg_type,
+                pre,
+                folder,
+                anim,
+                text,
+                pos,
+                sfx,
+                emote_mod,
+                cid,
+                sfx_delay,
+                button,
+                evidence,
+                flip,
+                ding,
+                color,
+                showname,
+                charid_pair,
+                offset_pair,
+                nonint_pre,
+                sfx_looping,
+                screenshake,
+                frames_shake,
+                frames_realization,
+                frames_sfx,
+                additive,
+                effect,
+                blipname,
+                slide,
+            ) = args
+            try:
+                pair_args = charid_pair.split("^")
+                charid_pair = int(pair_args[0])
+                if len(pair_args) > 1:
+                    pair_order = pair_args[1]
+            except ValueError:
+                self.client.send_ooc(
+                    "Something went wrong! Please report the issue to the developers.")
+                return
         else:
             return
 
@@ -612,6 +685,7 @@ class AOProtocol(asyncio.Protocol):
             frames_realization = derelative(frames_realization)
             frames_sfx = derelative(frames_sfx)
             effect = derelative(effect)
+            blipname = derelative(blipname)
 
         if not self.client.is_mod and not (self.client in self.client.area.owners):
             if not self.client.area.blankposting_allowed:
@@ -1081,6 +1155,8 @@ class AOProtocol(asyncio.Protocol):
                         third_emote, # 32
                         third_offset, # 33
                         third_flip, # 33
+                        blipname, #34
+                        slide, #35
                     )
                 a_list = ", ".join([str(a.id) for a in target_area])
                 if not (self.client.area in target_area):
@@ -1123,6 +1199,8 @@ class AOProtocol(asyncio.Protocol):
                         third_emote,
                         third_offset,
                         third_flip,
+                        blipname,
+                        slide,
                     )
                 self.client.send_ooc(f"Broadcasting to areas {a_list}")
             except (AreaError, ValueError):
@@ -1249,6 +1327,8 @@ class AOProtocol(asyncio.Protocol):
                         third_emote,
                         third_offset,
                         third_flip,
+                        blipname,
+                        slide,
                     )
 
             return
@@ -1296,6 +1376,8 @@ class AOProtocol(asyncio.Protocol):
             frames_sfx=frames_sfx,
             additive=additive,
             effect=effect,
+            blipname=blipname,
+            slide=slide,
             targets=whisper_clients,
             third_charid=third_charid,
             third_folder=third_folder,
@@ -1341,6 +1423,8 @@ class AOProtocol(asyncio.Protocol):
             third_emote,
             third_offset,
             third_flip,
+            blipname,
+            slide,
         )
 
         # DRO client support

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -599,7 +599,7 @@ class AOProtocol(asyncio.Protocol):
             self.ArgType.STR, # 26 # blipname
             self.ArgType.INT, # 27 # slide
         ):
-            # 2.10 validation monstrosity. (FUCK IT WE BALL FUCK IT WE BALL FUCK IT WE BALL)
+            # 2.11 validation monstrosity. (FUCK IT WE BALL FUCK IT WE BALL FUCK IT WE BALL)
             (
                 msg_type,
                 pre,

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -67,6 +67,7 @@ class TsuServer3:
             "effects",
             "expanded_desk_mods",
             "y_offset",
+            "custom_blips",
         ]
         self.command_aliases = {}
 


### PR DESCRIPTION
Until the inevitable hotfix for whatever the fuck broke this time or something else needs adding.

* Adds compatability with Client 2.11 courtroom slides and emote specific blips. **Note, 2.11 isn't officially out yet so definitely _test this shit_ I swear to fuck. Even if it does work on my pc™, it took me nearly 2 weeks to figure out how to get this working in KFO-Server and all it needed was two words in tsuserver.py - I am not a smart man, merely persistent.**
* Everything else should still work as normal with 2.10 clients though so don't freak out even if that new validation monstrosity is looking wack (i lied, slides no longer work on 2.10 due to changes in how backgrounds are handled)
* """"""""""Fix"""""""""" /play'ing as a non-cm (it'll be fine, trust)
* Drank way too much rum. Or, mayhaps, not enough.