### PR TITLE
Shownames and WebAO segregation

### DIFF
--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -729,17 +729,11 @@ class ClientManager:
                             self.editing_minigame_song_condition = 0
 
                     # Showname info
-                    if showname != "":
-                        if (
-                            len(showname) > 0
-                            and not area.showname_changes_allowed
-                            and not self.is_mod
-                            and self not in area.owners
-                        ):
-                            self.send_ooc(
-                                f"Showname changes are forbidden in area [{area.id}] {area.name}!"
-                            )
-                            continue
+                    if (
+                        len(showname) > 0
+                        and not area.showname_changes_allowed
+                    ):
+                        showname = self.char_name
 
                     # Effects info
                     effects = int(effects)

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -616,6 +616,9 @@ class ClientManager:
                 return
             if cid != self.char_id:
                 return
+            if not self.hdid.startswith("S-"):
+                self.send_ooc("WebAO clients are blocked from using music. Get the client at https://aovidya.pw/AOV")
+                return
 
             # Decode AO packet
             song = song.replace("<num>", "#") \

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -661,9 +661,6 @@ class AOProtocol(asyncio.Protocol):
             len(showname) > 0
             and not self.client.area.showname_changes_allowed
         ):
-            self.client.send_ooc(
-                "Showname changes are forbidden in this area!")
-            #return
             showname = self.client.char_name
         if self.client.area.is_iniswap(self.client, pre, anim, folder, sfx):
             folder = self.client.char_name


### PR DESCRIPTION
- Remove "no shownames allowed warning" because it's baked in
- Perform a 360 windmill dunk on WebAO users so they can't use music anymore